### PR TITLE
Fix #144

### DIFF
--- a/business/src/main/java/com/kevinguanchedarias/owgejava/business/PlanetBo.java
+++ b/business/src/main/java/com/kevinguanchedarias/owgejava/business/PlanetBo.java
@@ -15,7 +15,6 @@ import com.kevinguanchedarias.owgejava.dto.PlanetDto;
 import com.kevinguanchedarias.owgejava.entity.ExploredPlanet;
 import com.kevinguanchedarias.owgejava.entity.Planet;
 import com.kevinguanchedarias.owgejava.entity.UserStorage;
-import com.kevinguanchedarias.owgejava.enumerations.MissionType;
 import com.kevinguanchedarias.owgejava.exception.SgtBackendInvalidInputException;
 import com.kevinguanchedarias.owgejava.exception.SgtBackendUniverseIsFull;
 import com.kevinguanchedarias.owgejava.repository.ExploredPlanetRepository;
@@ -216,8 +215,7 @@ public class PlanetBo implements WithNameBo<Long, Planet, PlanetDto> {
 	public boolean canLeavePlanet(Integer invokerId, Long planetId) {
 		return !isHomePlanet(planetId) && isOfUserProperty(invokerId, planetId)
 				&& !obtainedUnitBo.hasUnitsInPlanet(invokerId, planetId)
-				&& missionBo.findRunningUnitBuild(invokerId, Double.valueOf(planetId)) == null
-				&& !missionBo.existsByTargetPlanetAndType(planetId, MissionType.RETURN_MISSION);
+				&& missionBo.findRunningUnitBuild(invokerId, Double.valueOf(planetId)) == null;
 	}
 
 }

--- a/business/src/main/java/com/kevinguanchedarias/owgejava/entity/ObtainedUpgrade.java
+++ b/business/src/main/java/com/kevinguanchedarias/owgejava/entity/ObtainedUpgrade.java
@@ -72,8 +72,23 @@ public class ObtainedUpgrade implements EntityWithId<Long> {
 		this.level = level;
 	}
 
+	/**
+	 * 
+	 * @deprecated Use isAvailable instead()
+	 * @return
+	 */
+	@Deprecated(since = "0.8.1")
 	public Boolean getAvailable() {
 		return available;
+	}
+
+	/**
+	 * 
+	 * @since 0.8.1
+	 * @return
+	 */
+	public boolean isAvailable() {
+		return Boolean.TRUE.equals(available);
 	}
 
 	public void setAvailable(Boolean available) {

--- a/business/src/main/java/com/kevinguanchedarias/owgejava/repository/ObtainedUnitRepository.java
+++ b/business/src/main/java/com/kevinguanchedarias/owgejava/repository/ObtainedUnitRepository.java
@@ -50,8 +50,8 @@ public interface ObtainedUnitRepository extends JpaRepository<ObtainedUnit, Long
 
 	public List<ObtainedUnit> findByUserIdAndSourcePlanetIdAndMissionIdIsNull(Integer userId, Long planetId);
 
-	@Query("SELECT ou FROM ObtainedUnit ou LEFT JOIN ou.mission LEFT JOIN ou.mission.type WHERE ou.sourcePlanet.id = ?1 AND(ou.mission.id IS NULL OR ou.mission.type.code = 'DEPLOYED') ")
-	public List<ObtainedUnit> findBySourcePlanetIdAndMissionIsNullOrDeployed(Long planetId);
+	@Query("SELECT ou FROM ObtainedUnit ou LEFT JOIN ou.mission LEFT JOIN ou.mission.type WHERE ou.mission.id != ?1 AND (ou.mission.id IS NULL AND ou.sourcePlanet.id = ?2) OR (ou.mission.type.code = 'DEPLOYED' AND ou.targetPlanet.id = ?2) ")
+	public List<ObtainedUnit> findByExplorePlanet(Long exploreMissionId, Long planetId);
 
 	public List<ObtainedUnit> findBySourcePlanetIdAndMissionIsNull(Long id);
 
@@ -73,5 +73,29 @@ public interface ObtainedUnitRepository extends JpaRepository<ObtainedUnit, Long
 
 	@Query("SELECT SUM(utg.value * ou.count) FROM ObtainedUnit ou INNER JOIN ou.unit.improvement.unitTypesUpgrades utg WHERE ou.user = ?1 AND utg.type = ?2")
 	public Long sumByUserAndImprovementUnitTypeImprovementType(UserStorage user, String name);
+
+	/**
+	 * 
+	 * @param userId
+	 * @param unitId
+	 * @param planetId
+	 * @return
+	 * @author Kevin Guanche Darias <kevin@kevinguanchedarias.com>
+	 * @since 0.8.1
+	 */
+	public ObtainedUnit findOneByUserIdAndUnitIdAndSourcePlanetIdAndMissionIsNull(Integer userId, Integer unitId,
+			Long planetId);
+
+	/**
+	 * 
+	 * @param userId
+	 * @param unitId
+	 * @param planetId
+	 * @return
+	 * @author Kevin Guanche Darias <kevin@kevinguanchedarias.com>
+	 * @since 0.8.1
+	 */
+	public ObtainedUnit findOneByUserIdAndUnitIdAndTargetPlanetIdAndMissionTypeCode(Integer userId, Integer unitId,
+			Long planetId, String missionCode);
 
 }

--- a/business/src/test/java/com/kevinguanchedarias/owgejava/test/tests/ObtainedUnitBoTest.java
+++ b/business/src/test/java/com/kevinguanchedarias/owgejava/test/tests/ObtainedUnitBoTest.java
@@ -22,7 +22,6 @@ import com.kevinguanchedarias.owgejava.entity.Planet;
 import com.kevinguanchedarias.owgejava.entity.Unit;
 import com.kevinguanchedarias.owgejava.entity.UserStorage;
 import com.kevinguanchedarias.owgejava.exception.SgtBackendInvalidInputException;
-import com.kevinguanchedarias.owgejava.exception.SgtBackendNotImplementedException;
 import com.kevinguanchedarias.owgejava.repository.ObtainedUnitRepository;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -62,53 +61,6 @@ public class ObtainedUnitBoTest {
 		sourcePlanet = new Planet();
 		sourcePlanet.setId(SOURCE_PLANET_ID);
 		Mockito.when(planetBoMock.isOfUserProperty(USER_ID, SOURCE_PLANET_ID)).thenReturn(true);
-	}
-
-	@Test(expected = SgtBackendNotImplementedException.class)
-	public void shouldThrowBecauseNonDeployedInLocalPlanetSavingIsNotSupported() {
-		Planet otherPlanet = new Planet();
-		otherPlanet.setId(2L);
-		obtainedUnit.setSourcePlanet(otherPlanet);
-		obtainedUnitBo.saveWithAdding(USER_ID, obtainedUnit);
-	}
-
-	@Test
-	public void shouldSaveAddedOneWhenUnitDoesNotExistsInDatabase() {
-		obtainedUnit.setSourcePlanet(sourcePlanet);
-
-		obtainedUnitBo.saveWithAdding(USER_ID, obtainedUnit);
-		Mockito.verify(repositoryMock).save(obtainedUnit);
-		Mockito.verify(repositoryMock, Mockito.never()).delete(Mockito.any(ObtainedUnit.class));
-	}
-
-	@Test
-	public void shouldSaveExistingOneWhenUnitExistsInDatabaseDeletingAddedIfHasId() {
-		obtainedUnit.setSourcePlanet(sourcePlanet);
-
-		ObtainedUnit existingOne = new ObtainedUnit();
-		existingOne.setId(2L);
-		existingOne.setCount(1L);
-		Mockito.when(repositoryMock.findOneByUserIdAndUnitIdAndSourcePlanetIdAndIdNotAndMissionNull(USER_ID, UNIT_ID,
-				SOURCE_PLANET_ID, obtainedUnit.getId())).thenReturn(existingOne);
-		obtainedUnitBo.saveWithAdding(USER_ID, obtainedUnit);
-		Mockito.verify(repositoryMock).save(existingOne);
-		Mockito.verify(repositoryMock).delete(obtainedUnit);
-
-	}
-
-	@Test
-	public void shouldSaveExistingOneWhenUnitExistsInDatabaseNotDeletingIfHasNotId() {
-		obtainedUnit.setSourcePlanet(sourcePlanet);
-		obtainedUnit.setId(null);
-
-		ObtainedUnit existingOne = new ObtainedUnit();
-		existingOne.setId(2L);
-		existingOne.setCount(1L);
-		Mockito.when(repositoryMock.findOneByUserIdAndUnitIdAndSourcePlanetIdAndIdNotAndMissionNull(USER_ID, UNIT_ID,
-				SOURCE_PLANET_ID, obtainedUnit.getId())).thenReturn(existingOne);
-		obtainedUnitBo.saveWithAdding(USER_ID, obtainedUnit);
-		Mockito.verify(repositoryMock).save(existingOne);
-		Mockito.verify(repositoryMock, Mockito.never()).delete(obtainedUnit);
 	}
 
 	@Test(expected = SgtBackendInvalidInputException.class)

--- a/game-frontend/CHANGELOG.md
+++ b/game-frontend/CHANGELOG.md
@@ -3,6 +3,8 @@
 v0.8.1 (latest)
 =================
 
+* __Fix:__ [Can't leave base X when a mission from base Y to base X is in return state #144
+](https://github.com/KevinGuancheDarias/owge/issues/144)
 * [class=Admin] __Fix:__ [Admin configuration for mission times, is getting reset each time the backend restarts #141](https://github.com/KevinGuancheDarias/owge/issues/141) 
 * [class=Advanced] __Improvement:__ Allow to expose dockerized SQS server, when you want to run your backend manually
 * [class=Advanced] __Fix:__ In OWGE Docker Launcher, advanced pro guys profile was not working  


### PR DESCRIPTION
    Strong refactor of the way engine stores the current location of the unit, may fix other pending issues

    sourcePlanet should always refer to the planet where the unit belongs to
    targetPlanet should always refer to ... the planet that a mission is going to